### PR TITLE
fix(fang): incorrect \. regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [UNRELEASED]
 
+## [4.2.1] - 2022.09.27
+
+### Fixed
+
+- Fixed incorrect find regex producing overly broad fanging of any character preceeded with a `\` ([#99](https://github.com/ioc-fang/ioc-fanger/issues/99))
+
 ## [4.2.0] - 2022.09.17
 
 ### Changed

--- a/ioc_fanger/regexes_fang.py
+++ b/ioc_fanger/regexes_fang.py
@@ -149,7 +149,7 @@ fang_patterns: List = [
     {"find": r"(\<\.\>)", "replace": "."},
     {
         # "\." -> "."
-        "find": r"(\\.)",
+        "find": r"(\\\.)",
         "replace": ".",
     },
 ]

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -432,3 +432,7 @@ def test_pr_99__escaped_periods():
     result = ioc_fanger.fang(s)
     assert result == "HKLM\\SOFTWARE\\foo bar\\bing buzz boom\\b"
 
+    s = "foo$.bar foo\\.bar"
+    result = ioc_fanger.fang(s)
+    assert result == "foo$.bar foo.bar"
+

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -425,3 +425,10 @@ def test_alternative_schemes_preserved():
     s = "ldap://example.com/a"
     result = ioc_fanger.fang(s)
     assert result == "ldap://example.com/a"
+
+
+def test_pr_99__escaped_periods():
+    s = "HKLM\\SOFTWARE\\foo bar\\bing buzz boom\\b"
+    result = ioc_fanger.fang(s)
+    assert result == "HKLM\\SOFTWARE\\foo bar\\bing buzz boom\\b"
+


### PR DESCRIPTION
I intended this regex to match `\.`, but instead, it was matching `\` followed by *any* character.