### PR TITLE
Constrain comma-IP fang regex to valid 0-255 octets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Docker-based local development; `uv` is now the supported way to test/lint/develop. Docker is retained only to generate and compare a Linux benchmark baseline that matches CI.
 - `requirements.txt` and `requirements_dev.txt` (use `uv sync --locked --group dev` to set up a dev environment)
 
+### Fixed
+
+- Constrained the comma-separated IP fang regex (`a,b,c,d`) to require each octet to be in the valid IPv4 range `0-255`, so strings like `999,999,999,999` no longer match the IPv4 fang pattern ([#121](https://github.com/ioc-fang/ioc-fanger/pull/121))
+
 ## [4.2.1] - 2022.09.27
 
 ### Fixed

--- a/ioc_fanger/regexes_fang.py
+++ b/ioc_fanger/regexes_fang.py
@@ -140,8 +140,16 @@ fang_patterns: List = [
         "replace": "@",
     },
     {
-        # Fang any ip address-esque item with commas between the numbers to have "." between the numbers
-        "find": r"(?:^|(?<=\s))([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3})(?=\s|$)",
+        # Fang any ip address-esque item with commas between the numbers to have "." between the numbers.
+        # Each octet is constrained to 0-255 so we don't match obvious non-IPs like "999,999,999,999".
+        "find": (
+            r"(?:^|(?<=\s))"
+            r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?),"
+            r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?),"
+            r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?),"
+            r"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+            r"(?=\s|$)"
+        ),
         "replace": r"\1.\2.\3.\4",
     },
     {"find": r"(\\/)", "replace": "/"},

--- a/tests/test_ip_address_handling.py
+++ b/tests/test_ip_address_handling.py
@@ -18,3 +18,24 @@ import ioc_fanger
 )
 def test_issue_71__overzealous_fanging_of_comma_seperated_nums(input, expected_output):
     assert ioc_fanger.fang(input) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input,expected_output",
+    [
+        # 999 is not a valid IPv4 octet, leave it alone
+        ("999,999,999,999", "999,999,999,999"),
+        # Out-of-range last octet leaves the whole match alone
+        ("1,2,3,256", "1,2,3,256"),
+        # Out-of-range first octet leaves the whole match alone
+        ("300,1,1,1", "300,1,1,1"),
+        # Boundary: 255.255.255.255 is valid
+        ("255,255,255,255", "255.255.255.255"),
+        # Boundary: 0.0.0.0 is valid
+        ("0,0,0,0", "0.0.0.0"),
+        # A valid IP next to an invalid one only fangs the valid one
+        ("1,2,3,4 999,999,999,999", "1.2.3.4 999,999,999,999"),
+    ],
+)
+def test_issue_93__only_fang_octets_in_0_to_255(input, expected_output):
+    assert ioc_fanger.fang(input) == expected_output


### PR DESCRIPTION
Closes #93

## Why

The regex that fangs comma-separated IP-shaped strings (e.g. \`1,2,3,4\` -> \`1.2.3.4\`) was matching anything in \`[0-9]{1,3}\` per group, so \`999,999,999,999\` ended up rewritten to \`999.999.999.999\`. The example in the issue.

## What

Replace each \`[0-9]{1,3}\` group with the standard 0-255 alternation:

```
25[0-5] | 2[0-4][0-9] | [01]?[0-9][0-9]?
```

so only legitimate IPv4 octets are fanged. The four-group structure, leading/trailing whitespace anchors, and `\1.\2.\3.\4` replacement are unchanged, so the existing #71 cases keep behaving the same way.

## Tests

`tests/test_ip_address_handling.py` already had a parametrised block for issue #71. I added a sibling block for #93 with six cases:

- `999,999,999,999` stays as-is (the example in the issue)
- `1,2,3,256` and `300,1,1,1` stay as-is (boundary failures at last/first octet)
- `255,255,255,255` and `0,0,0,0` are fanged (boundary successes)
- `1,2,3,4 999,999,999,999` -> `1.2.3.4 999,999,999,999` (one valid + one invalid on the same line; only the valid one fangs)

Locally:

```
$ python3 -m pytest tests/ --override-ini='addopts='
========================== 43 passed, 2 warnings in 0.05s ==========================
```