### PR TITLE
Add type annotations to public fang/defang functions

### DIFF
--- a/ioc_fanger/ioc_fanger.py
+++ b/ioc_fanger/ioc_fanger.py
@@ -6,7 +6,7 @@ from ioc_fanger.regexes_defang import defang_mappings
 from ioc_fanger.regexes_fang import fang_mappings
 
 
-def fang(text: str, debug=False):
+def fang(text: str, debug: bool = False) -> str:
     """Fang the indicators in the given text."""
     fanged_text = text
 
@@ -29,7 +29,7 @@ def fang(text: str, debug=False):
 
 @click.command()
 @click.argument("text", required=False)
-def cli_fang(text):
+def cli_fang(text: str | None) -> None:
     """CLI interface for fanging indicators."""
     if text:
         fanged_text = fang(text)
@@ -43,7 +43,7 @@ def cli_fang(text):
             print(fanged_text)
 
 
-def defang(text):
+def defang(text: str) -> str:
     """Defang the indicators in the given text."""
     defanged_text = text
 
@@ -55,7 +55,7 @@ def defang(text):
 
 @click.command()
 @click.argument("text", required=False)
-def cli_defang(text):
+def cli_defang(text: str | None) -> None:
     """CLI interface for defanging indicators."""
     if text:
         defanged_text = defang(text)

--- a/ioc_fanger/regexes_defang.py
+++ b/ioc_fanger/regexes_defang.py
@@ -1,6 +1,7 @@
 import re
+from typing import List
 
-defang_patterns = [
+defang_patterns: List = [
     {
         # "example.com" -> "example[.]com"
         "find": r"""

--- a/ioc_fanger/regexes_defang.py
+++ b/ioc_fanger/regexes_defang.py
@@ -1,7 +1,6 @@
 import re
-from typing import List
 
-defang_patterns: List = [
+defang_patterns: list = [
     {
         # "example.com" -> "example[.]com"
         "find": r"""


### PR DESCRIPTION
## Summary
- Annotate the four public functions in `ioc_fanger/ioc_fanger.py` (`fang`, `defang`, `cli_fang`, `cli_defang`). `fang` already had `text: str`; this fills in `debug: bool = False`, `-> str`, and adds `text: str | None` / `-> None` to the two Click entry points (Click passes `None` when the optional argument is omitted).
- Apply the existing `defang_patterns: List` mypy workaround from `regexes_fang.py` to `regexes_defang.py` so `mapping["find"].sub(...)` in `defang()` type-checks.
- `uv run mypy ioc_fanger tests` is clean.

Closes #44.

## Test plan
- [ ] CI passes on Python 3.10–3.14 (`str | None` requires 3.10+, which matches `requires-python` in `pyproject.toml`).
- [ ] Existing test suite still green — annotations only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)