### PR TITLE
Replace debug prints with logging (#70)

### DIFF
--- a/ioc_fanger/ioc_fanger.py
+++ b/ioc_fanger/ioc_fanger.py
@@ -1,9 +1,13 @@
 """Fang and defang indicators of compromise."""
 
+import logging
+
 import click
 
 from ioc_fanger.regexes_defang import defang_mappings
 from ioc_fanger.regexes_fang import fang_mappings
+
+logger = logging.getLogger(__name__)
 
 
 def fang(text: str, debug=False):
@@ -11,18 +15,20 @@ def fang(text: str, debug=False):
     fanged_text = text
 
     if debug:
-        print(f"Starting text: {fanged_text}")
-        print("-----")
+        logger.setLevel(logging.DEBUG)
+        if not logger.handlers:
+            logger.addHandler(logging.StreamHandler())
+
+    logger.debug("Starting text: %s", fanged_text)
+    logger.debug("-----")
 
     for mapping in fang_mappings:
-        if debug:
-            print(f"Mapping: {mapping}")
+        logger.debug("Mapping: %s", mapping)
 
         fanged_text = mapping["find"].sub(mapping["replace"], fanged_text)
 
-        if debug:
-            print(f"Text after mapping: {fanged_text}")
-            print("-----")
+        logger.debug("Text after mapping: %s", fanged_text)
+        logger.debug("-----")
 
     return fanged_text
 

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -5,9 +5,12 @@ test_ioc_fanger
 Tests for `ioc_fanger` module.
 """
 
+import logging
+
 import pytest
 
 import ioc_fanger
+from ioc_fanger import ioc_fanger as ioc_fanger_module
 
 
 @pytest.fixture
@@ -425,3 +428,42 @@ def test_pr_99__escaped_periods():
     s = "foo$.bar foo\\.bar"
     result = ioc_fanger.fang(s)
     assert result == "foo$.bar foo.bar"
+
+
+@pytest.fixture
+def reset_fang_logger():
+    logger = ioc_fanger_module.logger
+    original_level = logger.level
+    original_handlers = logger.handlers[:]
+    logger.handlers = []
+    logger.setLevel(logging.NOTSET)
+    yield logger
+    logger.handlers = original_handlers
+    logger.setLevel(original_level)
+
+
+def test_fang_debug_emits_log_records(reset_fang_logger, caplog):
+    """When debug=True, fang emits DEBUG-level log records via the module logger."""
+    with caplog.at_level(logging.DEBUG, logger=reset_fang_logger.name):
+        ioc_fanger.fang("hxxp://example[.]com", debug=True)
+
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+    assert any("Starting text: hxxp://example[.]com" in m for m in debug_messages)
+    assert any(m.startswith("Mapping: ") for m in debug_messages)
+    assert any(m.startswith("Text after mapping: ") for m in debug_messages)
+
+
+def test_fang_debug_sets_logger_level_and_handler(reset_fang_logger):
+    """debug=True sets the logger to DEBUG and attaches a handler so output is visible."""
+    ioc_fanger.fang("hxxp://example[.]com", debug=True)
+
+    assert reset_fang_logger.level == logging.DEBUG
+    assert any(isinstance(h, logging.StreamHandler) for h in reset_fang_logger.handlers)
+
+
+def test_fang_default_does_not_emit_debug_records(reset_fang_logger, caplog):
+    """Without debug=True, no DEBUG-level records are surfaced through the root config."""
+    with caplog.at_level(logging.WARNING, logger=reset_fang_logger.name):
+        ioc_fanger.fang("hxxp://example[.]com")
+
+    assert [r for r in caplog.records if r.levelno == logging.DEBUG] == []


### PR DESCRIPTION
## Summary
- Replace `print()` calls in `fang(debug=True)` with a module logger emitting `logger.debug(...)` records
- When `debug=True`, set the logger to `DEBUG` and attach a `StreamHandler` if none exists, preserving the original visible-output UX
- CLI `print` calls (intentional user output) left unchanged
- Add tests asserting debug-mode log records, logger level/handler setup, and that no DEBUG records are emitted by default

Closes #70

## Test plan
- [x] `uv run pytest tests/` — 40 passed, 100% coverage
- [x] `uv run python -c "import ioc_fanger; ioc_fanger.fang('hxxp://example[.]com', debug=True)"` shows debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)