### PR TITLE
Add regex coverage tracking; close gaps from #92

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-<<<<<<< ioc-fang-ioc-fanger-92-make-sure-all-regexes-are-tested-claude
 from ioc_fanger import ioc_fanger as ioc_fanger_module
 from ioc_fanger.regexes_fang import fang_mappings
 
@@ -9,6 +8,34 @@ from ioc_fanger.regexes_fang import fang_mappings
 # installed below; consumed by tests/test_zz_regex_coverage.py.
 FANG_HITS: set[int] = set()
 DEFANG_HITS: set[str] = set()
+
+# (defanged_input, expected_fanged_output) — strings that fang() should transform
+DEFANG_TO_FANG_PAIRS = [
+    ("example[.]com", "example.com"),
+    ("hxxp://example[.]com", "http://example.com"),
+    ("hXXp://example[.]com", "http://example.com"),
+    ("example\\.com", "example.com"),
+    ("example^.com", "example.com"),
+    ("hxxp://example[.]com", "http://example.com"),
+    ("1[.]2[.]3[.]4", "1.2.3.4"),
+    ("bob[@]example[.]com", "bob@example.com"),
+    ("mary[@]example.com", "mary@example.com"),
+    ("carlos[at]example.com", "carlos@example.com"),
+    ("juanita(at)example.com", "juanita@example.com"),
+    ("http[:]//example.org", "http://example.org"),
+    ("https[:]//example.org", "https://example.org"),
+    ("hXxps[:]//example.org/test?target=bad[@]test.com", "https://example.org/test?target=bad@test.com"),
+    ("bad-dot-com", "bad.com"),
+    ("example-dot-ru", "example.ru"),
+    ("5[,]6[,]7(,)8", "5.6.7.8"),
+    ("9,10,11,12", "9.10.11.12"),
+]
+
+# strings that are already fanged and should pass through fang() unchanged
+ALREADY_FANGED_STRINGS = [
+    "example.com",
+    "http://example.com",
+]
 
 
 class _TrackedFangPattern:
@@ -53,35 +80,6 @@ def pytest_collection_modifyitems(config, items):
     coverage_items = [item for item in items if "test_regex_coverage" in item.nodeid]
     other_items = [item for item in items if "test_regex_coverage" not in item.nodeid]
     items[:] = other_items + coverage_items
-=======
-# (defanged_input, expected_fanged_output) — strings that fang() should transform
-DEFANG_TO_FANG_PAIRS = [
-    ("example[.]com", "example.com"),
-    ("hxxp://example[.]com", "http://example.com"),
-    ("hXXp://example[.]com", "http://example.com"),
-    ("example\\.com", "example.com"),
-    ("example^.com", "example.com"),
-    ("hxxp://example[.]com", "http://example.com"),
-    ("1[.]2[.]3[.]4", "1.2.3.4"),
-    ("bob[@]example[.]com", "bob@example.com"),
-    ("mary[@]example.com", "mary@example.com"),
-    ("carlos[at]example.com", "carlos@example.com"),
-    ("juanita(at)example.com", "juanita@example.com"),
-    ("http[:]//example.org", "http://example.org"),
-    ("https[:]//example.org", "https://example.org"),
-    ("hXxps[:]//example.org/test?target=bad[@]test.com", "https://example.org/test?target=bad@test.com"),
-    ("bad-dot-com", "bad.com"),
-    ("example-dot-ru", "example.ru"),
-    ("5[,]6[,]7(,)8", "5.6.7.8"),
-    ("9,10,11,12", "9.10.11.12"),
-]
-
-# strings that are already fanged and should pass through fang() unchanged
-ALREADY_FANGED_STRINGS = [
-    "example.com",
-    "http://example.com",
-]
->>>>>>> main
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,8 +49,8 @@ ioc_fanger_module._at_re = _TrackedDefangPattern(ioc_fanger_module._at_re, "_at_
 
 def pytest_collection_modifyitems(config, items):
     """Run the regex-coverage tests after everything else has had a chance to hit patterns."""
-    coverage_items = [item for item in items if "test_zz_regex_coverage" in item.nodeid]
-    other_items = [item for item in items if "test_zz_regex_coverage" not in item.nodeid]
+    coverage_items = [item for item in items if "test_regex_coverage" in item.nodeid]
+    other_items = [item for item in items if "test_regex_coverage" not in item.nodeid]
     items[:] = other_items + coverage_items
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from ioc_fanger.regexes_fang import fang_mappings
 
 # Module-level sets recording which regex patterns produced at least one
 # substitution during the test session. Populated by the tracking proxies
-# installed below; consumed by tests/test_zz_regex_coverage.py.
+# installed below; consumed by tests/test_regex_coverage.py.
 FANG_HITS: set[int] = set()
 DEFANG_HITS: set[str] = set()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,8 @@ class _TrackedDefangPattern:
 for _i, _mapping in enumerate(fang_mappings):
     _mapping["find"] = _TrackedFangPattern(_mapping["find"], _i)
 
-ioc_fanger_module._dot_re = _TrackedDefangPattern(ioc_fanger_module._dot_re, "_dot_re")
-ioc_fanger_module._at_re = _TrackedDefangPattern(ioc_fanger_module._at_re, "_at_re")
+ioc_fanger_module._dot_re = _TrackedDefangPattern(ioc_fanger_module._dot_re, "_dot_re")  # type: ignore[assignment]
+ioc_fanger_module._at_re = _TrackedDefangPattern(ioc_fanger_module._at_re, "_at_re")  # type: ignore[assignment]
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,58 @@
 import pytest
 
+from ioc_fanger import ioc_fanger as ioc_fanger_module
+from ioc_fanger.regexes_fang import fang_mappings
+
+# Module-level sets recording which regex patterns produced at least one
+# substitution during the test session. Populated by the tracking proxies
+# installed below; consumed by tests/test_zz_regex_coverage.py.
+FANG_HITS: set[int] = set()
+DEFANG_HITS: set[str] = set()
+
+
+class _TrackedFangPattern:
+    """Proxy around a compiled fang regex that records substitution hits."""
+
+    def __init__(self, pattern, index: int):
+        self._pattern = pattern
+        self._index = index
+
+    def sub(self, repl, text):
+        new_text, n = self._pattern.subn(repl, text)
+        if n > 0:
+            FANG_HITS.add(self._index)
+        return new_text
+
+
+class _TrackedDefangPattern:
+    """Proxy around a compiled defang regex that records substitution hits."""
+
+    def __init__(self, pattern, name: str):
+        self._pattern = pattern
+        self._name = name
+
+    def sub(self, repl, text):
+        new_text, n = self._pattern.subn(repl, text)
+        if n > 0:
+            DEFANG_HITS.add(self._name)
+        return new_text
+
+
+# Install tracking proxies. Only happens at test-collection time, so the
+# library itself remains uninstrumented when imported by normal callers.
+for _i, _mapping in enumerate(fang_mappings):
+    _mapping["find"] = _TrackedFangPattern(_mapping["find"], _i)
+
+ioc_fanger_module._dot_re = _TrackedDefangPattern(ioc_fanger_module._dot_re, "_dot_re")
+ioc_fanger_module._at_re = _TrackedDefangPattern(ioc_fanger_module._at_re, "_at_re")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Run the regex-coverage tests after everything else has had a chance to hit patterns."""
+    coverage_items = [item for item in items if "test_zz_regex_coverage" in item.nodeid]
+    other_items = [item for item in items if "test_zz_regex_coverage" not in item.nodeid]
+    items[:] = other_items + coverage_items
+
 
 @pytest.fixture
 def defanged_text():

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -461,6 +461,33 @@ def test_fang_debug_sets_logger_level_and_handler(reset_fang_logger):
     assert any(isinstance(h, logging.StreamHandler) for h in reset_fang_logger.handlers)
 
 
+def test_postceded_only_dot_word_variants():
+    """Bracket only on the trailing side of dot/punto/punkt — exercises the postceded-only fang pattern."""
+    assert ioc_fanger.fang("foodot]com") == "foo.com"
+    assert ioc_fanger.fang("foopunto)com") == "foo.com"
+    assert ioc_fanger.fang("foopunkt}com") == "foo.com"
+
+
+def test_postceded_only_lowercase_at_variants():
+    """Bracket only on the trailing side of lowercase at/et/arroba — exercises the postceded-only fang pattern."""
+    assert ioc_fanger.fang("fooat]bar.com") == "foo@bar.com"
+    assert ioc_fanger.fang("fooet)bar.com") == "foo@bar.com"
+    assert ioc_fanger.fang("fooarroba}bar.com") == "foo@bar.com"
+
+
+def test_postceded_only_uppercase_AT_variants():
+    """Bracket only on the trailing side of uppercase AT/ET/ARROBA — exercises the postceded-only fang pattern."""
+    assert ioc_fanger.fang("fooAT]bar.com") == "foo@bar.com"
+    assert ioc_fanger.fang("fooET)bar.com") == "foo@bar.com"
+    assert ioc_fanger.fang("fooARROBA}bar.com") == "foo@bar.com"
+
+
+def test_postceded_only_http_brackets():
+    """Bracket only on the trailing side of http(s) — exercises the postceded-only fang pattern."""
+    assert ioc_fanger.fang("http]://example.com") == "http://example.com"
+    assert ioc_fanger.fang("https]://example.com") == "https://example.com"
+
+
 def test_fang_default_does_not_emit_debug_records(reset_fang_logger, caplog):
     """Without debug=True, no DEBUG-level records are surfaced through the root config."""
     with caplog.at_level(logging.WARNING, logger=reset_fang_logger.name):

--- a/tests/test_regex_coverage.py
+++ b/tests/test_regex_coverage.py
@@ -2,8 +2,8 @@
 
 The conftest installs tracking proxies around each compiled pattern that record
 a hit whenever a substitution actually occurs. This module asserts that every
-pattern was hit by the rest of the test suite. It is forced to run last via
-``pytest_collection_modifyitems`` in conftest.py.
+pattern was hit by the rest of the test suite. The tests in this module are
+forced to run last via ``pytest_collection_modifyitems`` in conftest.py.
 """
 
 from ioc_fanger.regexes_fang import fang_patterns

--- a/tests/test_zz_regex_coverage.py
+++ b/tests/test_zz_regex_coverage.py
@@ -1,0 +1,28 @@
+"""Coverage check: every regex in ioc_fanger must be exercised by at least one test.
+
+The conftest installs tracking proxies around each compiled pattern that record
+a hit whenever a substitution actually occurs. This module asserts that every
+pattern was hit by the rest of the test suite. It is forced to run last via
+``pytest_collection_modifyitems`` in conftest.py.
+"""
+
+from ioc_fanger.regexes_fang import fang_patterns
+
+from tests.conftest import DEFANG_HITS, FANG_HITS
+
+
+def test_all_fang_regexes_exercised():
+    expected = set(range(len(fang_patterns)))
+    missing = sorted(expected - FANG_HITS)
+    if missing:
+        details = "\n".join(f"  [{i}] {fang_patterns[i]['find']}" for i in missing)
+        raise AssertionError(
+            f"{len(missing)} fang regex(es) were never exercised by any test:\n{details}\n"
+            "Add a test that triggers a substitution for each pattern above."
+        )
+
+
+def test_all_defang_regexes_exercised():
+    expected = {"_dot_re", "_at_re"}
+    missing = sorted(expected - DEFANG_HITS)
+    assert not missing, f"Defang regex(es) never exercised: {missing}"

--- a/tests/test_zz_regex_coverage.py
+++ b/tests/test_zz_regex_coverage.py
@@ -7,7 +7,6 @@ pattern was hit by the rest of the test suite. It is forced to run last via
 """
 
 from ioc_fanger.regexes_fang import fang_patterns
-
 from tests.conftest import DEFANG_HITS, FANG_HITS
 
 


### PR DESCRIPTION
## Summary
- Wraps every compiled fang/defang regex in a tracking proxy at test-collection time so we can assert each pattern is exercised by at least one test. Instrumentation lives entirely in `tests/conftest.py` — the library itself is unchanged.
- Adds `tests/test_zz_regex_coverage.py` with two assertions: every entry in `fang_patterns` was hit, and both defang regexes were hit. Forced to run last via `pytest_collection_modifyitems`. Failure messages list the exact unexercised patterns.
- Adds tests for the four postceded-only patterns the new check identified as unexercised, including the `@/at/et/arroba` regex called out in #92.

Closes #92.

## Test plan
- [ ] `uv run pytest` — all 52 tests pass, 100% line coverage maintained
- [ ] Temporarily delete one of the new postceded-only tests and confirm `test_all_fang_regexes_exercised` reports the missing pattern with its source regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)