### PR TITLE
Group fang tests by behavior rather than interspersing inputs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,39 @@
 import pytest
 
+# (defanged_input, expected_fanged_output) — strings that fang() should transform
+DEFANG_TO_FANG_PAIRS = [
+    ("example[.]com", "example.com"),
+    ("hxxp://example[.]com", "http://example.com"),
+    ("hXXp://example[.]com", "http://example.com"),
+    ("example\\.com", "example.com"),
+    ("example^.com", "example.com"),
+    ("hxxp://example[.]com", "http://example.com"),
+    ("1[.]2[.]3[.]4", "1.2.3.4"),
+    ("bob[@]example[.]com", "bob@example.com"),
+    ("mary[@]example.com", "mary@example.com"),
+    ("carlos[at]example.com", "carlos@example.com"),
+    ("juanita(at)example.com", "juanita@example.com"),
+    ("http[:]//example.org", "http://example.org"),
+    ("https[:]//example.org", "https://example.org"),
+    ("hXxps[:]//example.org/test?target=bad[@]test.com", "https://example.org/test?target=bad@test.com"),
+    ("bad-dot-com", "bad.com"),
+    ("example-dot-ru", "example.ru"),
+    ("5[,]6[,]7(,)8", "5.6.7.8"),
+    ("9,10,11,12", "9.10.11.12"),
+]
+
+# strings that are already fanged and should pass through fang() unchanged
+ALREADY_FANGED_STRINGS = [
+    "example.com",
+    "http://example.com",
+]
+
 
 @pytest.fixture
 def defanged_text():
-    return "example[.]com hxxp://example[.]com hXXp://example[.]com example\.com example^.com example.com http://example.com hxxp://example[.]com 1[.]2[.]3[.]4 bob[@]example[.]com mary[@]example.com carlos[at]example.com juanita(at)example.com http[:]//example.org https[:]//example.org hXxps[:]//example.org/test?target=bad[@]test.com bad-dot-com example-dot-ru 5[,]6[,]7(,)8 9,10,11,12"
+    return " ".join([d for d, _ in DEFANG_TO_FANG_PAIRS] + ALREADY_FANGED_STRINGS)
 
 
 @pytest.fixture
 def fanged_text():
-    return "example.com http://example.com http://example.com example.com example.com example.com http://example.com http://example.com 1.2.3.4 bob@example.com mary@example.com carlos@example.com juanita@example.com http://example.org https://example.org https://example.org/test?target=bad@test.com bad.com example.ru 5.6.7.8 9.10.11.12"
+    return " ".join([f for _, f in DEFANG_TO_FANG_PAIRS] + ALREADY_FANGED_STRINGS)

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -12,6 +12,8 @@ import pytest
 import ioc_fanger
 from ioc_fanger import ioc_fanger as ioc_fanger_module
 
+from .conftest import ALREADY_FANGED_STRINGS, DEFANG_TO_FANG_PAIRS
+
 
 @pytest.fixture
 def defanged_email_address_text():
@@ -23,10 +25,16 @@ def fanged_email_address_text():
     return ("bob@example.com " * 10).strip()
 
 
-def test_fanging(defanged_text, fanged_text):
-    """Test fanging."""
-    test_fanged_text = ioc_fanger.fang(defanged_text)
-    assert test_fanged_text == fanged_text
+@pytest.mark.parametrize("defanged_input,expected_fanged", DEFANG_TO_FANG_PAIRS)
+def test_fanging(defanged_input, expected_fanged):
+    """Each defanged string is fanged to its expected form."""
+    assert ioc_fanger.fang(defanged_input) == expected_fanged
+
+
+@pytest.mark.parametrize("already_fanged", ALREADY_FANGED_STRINGS)
+def test_fang_passes_through_already_fanged(already_fanged):
+    """Strings that are already fanged should be returned unchanged by fang()."""
+    assert ioc_fanger.fang(already_fanged) == already_fanged
 
 
 def test_defanging(fanged_text):


### PR DESCRIPTION
## Summary
- Splits the `defanged_text` / `fanged_text` conftest fixtures into two explicit data structures: `DEFANG_TO_FANG_PAIRS` (defanged input → expected fanged output) and `ALREADY_FANGED_STRINGS` (passthrough strings).
- Parametrizes `test_fanging` over the pair list (one assertion per case) and adds `test_fang_passes_through_already_fanged` for the passthrough strings, so the "needs fanging" and "already fanged" concerns are no longer interspersed in one big string.
- The original concatenated fixtures still exist (derived from the new lists), so `test_ioc_fanger_cli.py` and `test_defanging` keep working unchanged.

Closes #87.

## Test plan
- [x] `uv run pytest tests/` — 65 passed, 100% coverage maintained
- [ ] Reviewer confirms the parametrized output makes failure cases easier to read

🤖 Generated with [Claude Code](https://claude.com/claude-code)