### PR TITLE
Show spinner while interactive docs terminal loads (#59)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,10 @@ ioc_fanger.fang("example[.]com hXXp://bad[.]com/phishing[.]php")
 ioc_fanger.defang("example.com http://bad.com/phishing.php")
 ```
 
+<div id="terminal-loading" class="terminal-loading">
+  <div class="terminal-loading__spinner" aria-hidden="true"></div>
+  <div class="terminal-loading__text">Loading Python runtime…</div>
+</div>
 <div id="terminal"></div>
 
 This terminal uses [Pyodide](https://pyodide.org/en/stable/index.html) to provide a Python 3.12 runtime in the browser using [WebAssembly](https://webassembly.org/). Enjoy!

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -16,6 +16,29 @@
         --size: 1.5;
         --color: rgba(255, 255, 255, 0.8);
       }
+      .terminal-loading {
+        display: flex;
+        align-items: center;
+        gap: 0.75em;
+        padding: 1em;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: var(--md-default-fg-color, #333);
+      }
+      .terminal-loading__spinner {
+        width: 1.25em;
+        height: 1.25em;
+        border: 2px solid currentColor;
+        border-right-color: transparent;
+        border-radius: 50%;
+        animation: terminal-loading-spin 0.8s linear infinite;
+        flex-shrink: 0;
+      }
+      @keyframes terminal-loading-spin {
+        to { transform: rotate(360deg); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .terminal-loading__spinner { animation-duration: 2.4s; }
+      }
     </style>
 
     <script>
@@ -24,10 +47,20 @@
           return new Promise((resolve) => setTimeout(resolve, s));
         }
 
+        function setLoadingText(text) {
+          const el = document.querySelector("#terminal-loading .terminal-loading__text");
+          if (el) el.textContent = text;
+        }
+        function hideLoading() {
+          const el = document.getElementById("terminal-loading");
+          if (el) el.remove();
+        }
+
         async function main() {
           globalThis.pyodide = await loadPyodide({
             indexURL: "https://cdn.jsdelivr.net/pyodide/v0.27.0/full/",
           });
+          setLoadingText("Installing ioc-fanger…");
           let namespace = pyodide.globals.get("dict")();
           pyodide.runPython(
             `
@@ -134,7 +167,7 @@
           });
 
           // startup commands
-          interpreter("print('')\nimport micropip\nawait micropip.install('ioc-fanger')\nprint('ioc-fanger succesfully installed 🎉')");
+          const startup = interpreter("print('')\nimport micropip\nawait micropip.install('ioc-fanger')\nprint('ioc-fanger succesfully installed 🎉')");
 
           window.term = term;
           pyconsole.stdout_callback = (s) => term.echo(s, { newline: false });
@@ -142,6 +175,8 @@
             term.error(s.trimEnd());
           };
           term.ready = Promise.resolve();
+
+          startup.finally(hideLoading);
           pyodide._module.on_fatal = async (e) => {
             term.error(
               "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers."
@@ -156,6 +191,14 @@
           };
         }
 
-        window.console_ready = main();
+        window.console_ready = main().catch((err) => {
+          const el = document.getElementById("terminal-loading");
+          if (el) {
+            const spinner = el.querySelector(".terminal-loading__spinner");
+            if (spinner) spinner.style.display = "none";
+            setLoadingText("Failed to load the interactive terminal. See the browser console for details.");
+          }
+          console.error(err);
+        });
       </script>
 {% endblock %}


### PR DESCRIPTION
## Changes

- Add a CSS spinner with status text above the `#terminal` div in `docs/index.md` so users see a loading indicator immediately on page load
- In `docs/overrides/main.html`, scope the spinner styles, swap the label from "Loading Python runtime…" to "Installing ioc-fanger…" once `loadPyodide()` resolves, and remove the indicator after the `micropip.install` startup command settles
- Honor `prefers-reduced-motion` by slowing the spinner animation
- If `main()` rejects (e.g. pyodide fails to load), hide the spinner and swap in a failure message instead of spinning forever

Closes #59