### PR TITLE
Add IDN regression test for issue #33

### DIFF
--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -377,6 +377,14 @@ def test_debug():
     assert ioc_fanger.fang(s, debug=True) == "192.168.4.2"
 
 
+def test_idns():
+    # https://github.com/ioc-fang/ioc-fanger/issues/33
+    assert ioc_fanger.defang("вирус.рф") == "вирус[.]рф"
+    assert ioc_fanger.fang("вирус[.]рф") == "вирус.рф"
+    assert ioc_fanger.defang("名がドメイン.中国") == "名がドメイン[.]中国"
+    assert ioc_fanger.fang("名がドメイン[.]中国") == "名がドメイン.中国"
+
+
 def test_issue_46():
     s = "div><div><br></div><div>hxxp://zeplin[.]atwebpages[.]com/inter[.]php</div><"
     result = ioc_fanger.fang(s)


### PR DESCRIPTION
## Changes

- Add `test_idns()` to `tests/test_ioc_fanger.py` covering Cyrillic (`вирус.рф`) and CJK (`名がドメイン.中国`) round-trips for both `fang()` and `defang()`
- No production code changes: the `defang.json` / pyparsing grammars referenced in issue #33 were removed in a later refactor, and the current `re.compile(r"(?<=\w)\.(?=\w)")` already handles IDNs because Python 3's `\w` matches Unicode word characters by default

Closes #33