### PR TITLE
Fix fanging of literal dot/DOT inside hostnames (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Faster `fang()` by skipping bracket-related regex passes when the input contains no brackets
 - Faster `defang()` by replacing the regex-mapping loop with direct `str.replace` calls for `http`/`https` and two precompiled regexes for `.` and `@`
 
+### Fixed
+
+- `fang()` no longer mistakes literal `dot`/`DOT` text inside URL hostnames for a defanged separator (#112). Lowercase `dot` is now only fanged when bordered by brackets or by hyphens on **both** sides (so `accounts.dot-star.online` is preserved). Bare uppercase `DOT` is only fanged when it sits inside a token with no real `.` and is not adjacent to other uppercase letters (so `WWW.MDOT.JXCSF.VIP/pay` is preserved while `fooDOTcom` still fangs to `foo.com`).
+
 ### Removed
 
 - Support for Python 3.7, 3.8, and 3.9 (minimum is now 3.10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- `fang()` no longer mistakes literal `dot`/`DOT` text inside URL hostnames for a defanged separator (#112). Lowercase `dot` is now only fanged when bordered by brackets or by hyphens on **both** sides (so `accounts.dot-star.online` is preserved). Bare uppercase `DOT` is only fanged when it sits inside a token with no real `.` and is not adjacent to other uppercase letters (so `WWW.MDOT.JXCSF.VIP/pay` is preserved while `fooDOTcom` still fangs to `foo.com`).
+- `fang()` no longer mistakes literal `dot`/`DOT` text inside URL hostnames for a defanged separator (#112). Lowercase `dot` is now only fanged when bordered by brackets or by hyphens on **both** sides (so `accounts.dot-example.online` is preserved). Bare uppercase `DOT` is only fanged when it sits inside a token with no real `.` and is not adjacent to other uppercase letters (so `WWW.MDOT.EXAMPLE.VIP/pay` is preserved while `fooDOTcom` still fangs to `foo.com`).
 
 ### Removed
 

--- a/ioc_fanger/regexes_fang.py
+++ b/ioc_fanger/regexes_fang.py
@@ -28,19 +28,41 @@ fang_patterns: List = [
         "requires_brackets": True,
     },
     {
-        # Fang "DOT" surrounded by any kind of bracket
-        "find": r"((\ *[\[\]\(\)\{\}]*\ *)DOT(\ *[\[\]\(\)\{\}]*\ *))",
+        # Fang "DOT" surrounded by brackets/hyphens (1+ on the left)
+        "find": r"((\ *[\[\]\(\)\{\}-]+\ *)DOT(\ *[\[\]\(\)\{\}-]*\ *))",
         "replace": ".",
         "case_sensitive": True,
     },
     {
-        # Fang any of the words in the middle of the regex preceded (and perhaps postceded) by any kind of bracket
-        "find": r"((\ *[\[\]\(\)\{\}-]+\ *)(?:dot|punto|punkt)(\ *[\[\]\(\)\{\}-]*\ *))",
+        # Fang "DOT" surrounded by brackets/hyphens (1+ on the right)
+        "find": r"((\ *[\[\]\(\)\{\}-]*\ *)DOT(\ *[\[\]\(\)\{\}-]+\ *))",
+        "replace": ".",
+        "case_sensitive": True,
+    },
+    {
+        # Fang bare "DOT" only when it sits inside a token that has no real `.`...
+        # and is not adjacent to other uppercase letters. This keeps `fooDOTcom` and...
+        # `foo@barDOTcom` working while preserving real-world tokens like `MDOT` in...
+        # `WWW.MDOT.JXCSF.VIP` (see ioc-fang/ioc-fanger#112).
+        "find": r"(?<!\S)([^\s.]*?)\ *(?<![A-Z])DOT(?![A-Z])\ *([^\s.]*?)(?!\S)",
+        "replace": r"\1.\2",
+        "case_sensitive": True,
+    },
+    {
+        # Fang dot/punto/punkt preceded by 1+ bracket (and perhaps postceded by brackets)
+        "find": r"((\ *[\[\]\(\)\{\}]+\ *)(?:dot|punto|punkt)(\ *[\[\]\(\)\{\}]*\ *))",
         "replace": ".",
     },
     {
-        # Fang any of the words in the middle of the regex postceded (and perhaps preceded) by any kind of bracket
-        "find": r"((\ *[\[\]\(\)\{\}-]*\ *)(?:dot|punto|punkt)(\ *[\[\]\(\)\{\}-]+\ *))",
+        # Fang dot/punto/punkt postceded by 1+ bracket (and perhaps preceded by brackets)
+        "find": r"((\ *[\[\]\(\)\{\}]*\ *)(?:dot|punto|punkt)(\ *[\[\]\(\)\{\}]+\ *))",
+        "replace": ".",
+    },
+    {
+        # Fang dot/punto/punkt with hyphens on BOTH sides (e.g. `foo-dot-com`).
+        # Hyphens on only one side are not treated as defang markers, so strings...
+        # like `accounts.dot-star.online` are preserved (ioc-fang/ioc-fanger#112).
+        "find": r"-+(?:dot|punto|punkt)-+",
         "replace": ".",
     },
     {

--- a/tests/test_dot_variants.py
+++ b/tests/test_dot_variants.py
@@ -83,3 +83,21 @@ def test_systematic_dot():
 
     s = "foo-dot-com"
     assert ioc_fanger.fang(s) == "foo.com"
+
+
+def test_issue_112_literal_dot_in_hostname_not_fanged():
+    """Literal `dot`/`DOT` inside a hostname must not be treated as a defang.
+
+    See https://github.com/ioc-fang/ioc-fanger/issues/112
+    """
+    # `dot-` with a hyphen on only one side is not a defang marker
+    s = "http://accounts.dot-star.online"
+    assert ioc_fanger.fang(s) == s
+
+    # bare uppercase `DOT` inside a hostname containing real periods is preserved
+    s = "WWW.MDOT.JXCSF.VIP/pay"
+    assert ioc_fanger.fang(s) == s
+
+    # lowercase variant is already preserved; keep a regression test for it too
+    s = "www.mdot.jxcsf.vip/pay"
+    assert ioc_fanger.fang(s) == s

--- a/tests/test_dot_variants.py
+++ b/tests/test_dot_variants.py
@@ -91,13 +91,13 @@ def test_issue_112_literal_dot_in_hostname_not_fanged():
     See https://github.com/ioc-fang/ioc-fanger/issues/112
     """
     # `dot-` with a hyphen on only one side is not a defang marker
-    s = "http://accounts.dot-star.online"
+    s = "http://accounts.dot-example.online"
     assert ioc_fanger.fang(s) == s
 
     # bare uppercase `DOT` inside a hostname containing real periods is preserved
-    s = "WWW.MDOT.JXCSF.VIP/pay"
+    s = "WWW.MDOT.EXAMPLE.VIP/pay"
     assert ioc_fanger.fang(s) == s
 
     # lowercase variant is already preserved; keep a regression test for it too
-    s = "www.mdot.jxcsf.vip/pay"
+    s = "www.mdot.example.vip/pay"
     assert ioc_fanger.fang(s) == s

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -469,6 +469,13 @@ def test_fang_debug_sets_logger_level_and_handler(reset_fang_logger):
     assert any(isinstance(h, logging.StreamHandler) for h in reset_fang_logger.handlers)
 
 
+def test_postceded_only_uppercase_DOT_variants():
+    """Bracket only on the trailing side of uppercase DOT — exercises the postceded-only fang pattern."""
+    assert ioc_fanger.fang("fooDOT]com") == "foo.com"
+    assert ioc_fanger.fang("fooDOT)com") == "foo.com"
+    assert ioc_fanger.fang("fooDOT}com") == "foo.com"
+
+
 def test_fang_default_does_not_emit_debug_records(reset_fang_logger, caplog):
     """Without debug=True, no DEBUG-level records are surfaced through the root config."""
     with caplog.at_level(logging.WARNING, logger=reset_fang_logger.name):

--- a/tests/test_ioc_fanger.py
+++ b/tests/test_ioc_fanger.py
@@ -483,7 +483,7 @@ def test_postceded_only_uppercase_DOT_variants():
     assert ioc_fanger.fang("fooDOT)com") == "foo.com"
     assert ioc_fanger.fang("fooDOT}com") == "foo.com"
 
-    
+
 def test_postceded_only_dot_word_variants():
     """Bracket only on the trailing side of dot/punto/punkt — exercises the postceded-only fang pattern."""
     assert ioc_fanger.fang("foodot]com") == "foo.com"


### PR DESCRIPTION
## Changes

- Require brackets, or hyphens on **both** sides, to fang lowercase `dot`/`punto`/`punkt`, so `accounts.dot-star.online` is preserved (a single trailing hyphen is no longer treated as a defang marker).
- Only fang bare uppercase `DOT` when it sits inside a token with no real `.` and is not adjacent to other uppercase letters, so `WWW.MDOT.JXCSF.VIP/pay` is preserved while `fooDOTcom` still fangs to `foo.com`.
- Add regression tests in `tests/test_dot_variants.py` for the three scenarios from issue #112.
- Note the fix in `CHANGELOG.md`.

Closes #112.