### PR TITLE
ci: cancel in-progress runs on new pushes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes
- Add a top-level `concurrency` group (keyed on `${{ github.workflow }}-${{ github.ref }}`) with `cancel-in-progress: true` to the PR-triggered CI/lint workflows so superseded runs are cancelled when a new commit is pushed