### PR TITLE
Fix ReDoS catastrophic backtracking in fang() patterns

### DIFF
--- a/ioc_fanger/regexes_fang.py
+++ b/ioc_fanger/regexes_fang.py
@@ -17,26 +17,26 @@ fang_patterns: List = [
         # Fang a period or comma surrounded by any kind of bracket
         # We don't allow spaces after the "." so we don't inadvertently fang valid sentences...
         # (e.g. we don't want to fang something like: "an example). [B]")
-        "find": r"((\ *[\[\]\(\)\{\}]{1}\ *)[.,]([\[\]\(\)\{\}]{1}\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}]{1}\ {0,3})[.,]([\[\]\(\)\{\}]{1}\ {0,3}))",
         "replace": ".",
         "requires_brackets": True,
     },
     {
         # Fang a colon surrounded by any kind of bracket
-        "find": r"((\ *[\[\]\(\)\{\}]{1}\ *):(\ *[\[\]\(\)\{\}]{1}\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}]{1}\ {0,3}):(\ {0,3}[\[\]\(\)\{\}]{1}\ {0,3}))",
         "replace": ":",
         "requires_brackets": True,
     },
     {
         # Fang "DOT" surrounded by brackets/hyphens (1+ on the left)
-        "find": r"((\ *[\[\]\(\)\{\}-]+\ *)DOT(\ *[\[\]\(\)\{\}-]*\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}-]+\ {0,3})DOT(\ {0,3}[\[\]\(\)\{\}-]*\ {0,3}))",
         "replace": ".",
         "case_sensitive": True,
         "requires_any": ["DOT"],
     },
     {
         # Fang "DOT" surrounded by brackets/hyphens (1+ on the right)
-        "find": r"((\ *[\[\]\(\)\{\}-]*\ *)DOT(\ *[\[\]\(\)\{\}-]+\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}-]*\ {0,3})DOT(\ {0,3}[\[\]\(\)\{\}-]+\ {0,3}))",
         "replace": ".",
         "case_sensitive": True,
         "requires_any": ["DOT"],
@@ -53,13 +53,13 @@ fang_patterns: List = [
     },
     {
         # Fang dot/punto/punkt preceded by 1+ bracket (and perhaps postceded by brackets)
-        "find": r"((\ *[\[\]\(\)\{\}]+\ *)(?:dot|punto|punkt)(\ *[\[\]\(\)\{\}]*\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}]+\ {0,3})(?:dot|punto|punkt)(\ {0,3}[\[\]\(\)\{\}]*\ {0,3}))",
         "replace": ".",
         "requires_any": ["dot", "punto", "punkt"],
     },
     {
         # Fang dot/punto/punkt postceded by 1+ bracket (and perhaps preceded by brackets)
-        "find": r"((\ *[\[\]\(\)\{\}]*\ *)(?:dot|punto|punkt)(\ *[\[\]\(\)\{\}]+\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}]*\ {0,3})(?:dot|punto|punkt)(\ {0,3}[\[\]\(\)\{\}]+\ {0,3}))",
         "replace": ".",
         "requires_any": ["dot", "punto", "punkt"],
     },
@@ -73,28 +73,28 @@ fang_patterns: List = [
     },
     {
         # Fang any of the words in the middle of the regex preceded (and perhaps postceded) by any kind of bracket
-        "find": r"((\ *[\[\]\(\{\}]+\ *)(?:@|(?:at)|(?:et)|(?:arroba))(\ *[\]\(\)\{\}]*\ *))",
+        "find": r"((\ {0,3}[\[\]\(\{\}]+\ {0,3})(?:@|(?:at)|(?:et)|(?:arroba))(\ {0,3}[\]\(\)\{\}]*\ {0,3}))",
         "replace": "@",
         "case_sensitive": True,
         "requires_brackets": True,
     },
     {
         # Fang any of the words in the middle of the regex postceded (and perhaps preceded) by any kind of bracket
-        "find": r"((\ *[\[\]\(\)\{\}]*\ *)(?:@|(?:at)|(?:et)|(?:arroba))(\ *[\]\(\)\{\}]+\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}]*\ {0,3})(?:@|(?:at)|(?:et)|(?:arroba))(\ {0,3}[\]\(\)\{\}]+\ {0,3}))",
         "replace": "@",
         "case_sensitive": True,
         "requires_brackets": True,
     },
     {
         # Fang 'AT', 'ET', or 'ARROBA' preceded by a parenthesis/square brackets and possibly postceded by the same.
-        "find": r"((\ *[\[\]\(\)\{\}]+\ *)(?:(?:AT)|(?:ET)|(?:ARROBA))(\ *[\[\]\(\)\{\}]*\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}]+\ {0,3})(?:(?:AT)|(?:ET)|(?:ARROBA))(\ {0,3}[\[\]\(\)\{\}]*\ {0,3}))",
         "replace": "@",
         "case_sensitive": True,
         "requires_brackets": True,
     },
     {
         # Fang 'AT', 'ET', or 'ARROBA' postceded by a parenthesis/square brackets and possibly preceded by the same.
-        "find": r"((\ *[\[\]\(\)\{\}]*\ *)(?:(?:AT)|(?:ET)|(?:ARROBA))(\ *[\[\]\(\)\{\}]+\ *))",
+        "find": r"((\ {0,3}[\[\]\(\)\{\}]*\ {0,3})(?:(?:AT)|(?:ET)|(?:ARROBA))(\ {0,3}[\[\]\(\)\{\}]+\ {0,3}))",
         "replace": "@",
         "case_sensitive": True,
         "requires_brackets": True,
@@ -108,7 +108,7 @@ fang_patterns: List = [
     },
     {
         # Fang "www" surrounded by any kind of bracket
-        "find": r"(([\[\]\(\)\{\}]{1}\ *)www(\ *[\[\]\(\)\{\}]{1}\ *))",
+        "find": r"(([\[\]\(\)\{\}]{1}\ {0,3})www(\ {0,3}[\[\]\(\)\{\}]{1}\ {0,3}))",
         "replace": "www",
         "requires_brackets": True,
     },
@@ -128,13 +128,13 @@ fang_patterns: List = [
         # Fang "https?" preceded by a parenthesis/square brackets and possibly postceded by the same.
         # We don't fang closing brackets before "https?" b/c this not properly handle markdown links...
         # e.g. "[a](https://example.com)" would become "[ahttps://example.com" which is not ideal
-        "find": r"(?:[\[\(\{]+\ *)htt(ps?)(?:\ *[\[\]\(\)\{\}]*\ *)",
+        "find": r"(?:[\[\(\{]+\ {0,3})htt(ps?)(?:\ {0,3}[\[\]\(\)\{\}]*\ {0,3})",
         "replace": r"htt\1",
         "requires_brackets": True,
     },
     {
         # Fang "https?" postceded by a parenthesis/square brackets and possibly preceded by the same.
-        "find": r"(?:[\[\]\(\)\{\}]*\ *)htt(ps?)(?:\ *[\[\]\(\)\{\}]+\ *)",
+        "find": r"(?:[\[\]\(\)\{\}]*\ {0,3})htt(ps?)(?:\ {0,3}[\[\]\(\)\{\}]+\ {0,3})",
         "replace": r"htt\1",
         "requires_brackets": True,
     },

--- a/tests/test_redos.py
+++ b/tests/test_redos.py
@@ -1,0 +1,53 @@
+"""Regression tests for ReDoS (catastrophic backtracking) in ``fang()``.
+
+A small, attacker-controllable input must not pin a CPU for seconds. See the
+security review (``report.md``): several fang patterns used a
+``\\ *[brackets]*\\ *`` idiom whose two space quantifiers could partition a long
+run of spaces in N+1 ways, producing super-polynomial backtracking when the
+trailing literal failed to match. Bounding the spaces to ``\\ {0,3}`` keeps
+matching linear in the length of the space run.
+"""
+
+import threading
+
+import pytest
+
+import ioc_fanger
+
+# Generous ceiling: post-fix these inputs fang in well under a millisecond;
+# pre-fix they take many seconds to minutes. 2s cleanly separates the two and
+# stays safe on slow CI.
+_TIME_BUDGET_SECONDS = 2.0
+
+# Each payload drives a different family of the vulnerable patterns over a long
+# whitespace run, then fails the trailing literal to force backtracking:
+#   - bracket + spaces (no marker)  -> the ``@``/``at`` and ``AT`` left-group patterns
+#   - a ``dot``/``DOT`` marker in the run -> the dot/punto/punkt and DOT patterns
+_ADVERSARIAL_INPUTS = [
+    "(" + " " * 4000 + "z",
+    "(" + " " * 2000 + "dot" + " " * 2000 + "z",
+    "-" + " " * 2000 + "DOT" + " " * 2000 + "z",
+    " " * 2000 + "at(" + " " * 2000 + "z",
+]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    _ADVERSARIAL_INPUTS,
+    ids=["brackets+spaces", "dot-marker", "DOT-marker", "at-marker"],
+)
+def test_fang_no_catastrophic_backtracking(payload):
+    """fang() returns promptly on adversarial whitespace runs (no ReDoS)."""
+    result: list = []
+
+    def _run():
+        result.append(ioc_fanger.fang(payload))
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(_TIME_BUDGET_SECONDS)
+
+    assert not worker.is_alive(), (
+        f"fang() did not finish within {_TIME_BUDGET_SECONDS}s on a "
+        f"{len(payload)}-byte input - catastrophic backtracking (ReDoS)."
+    )


### PR DESCRIPTION
## Changes

- Bound the flanking space quantifiers (`\ *` → `\ {0,3}`) in the 13 fang patterns that used the `\ *[brackets]<q>\ *` idiom, eliminating super-polynomial regex backtracking (ReDoS) reachable via the public `fang()` API on untrusted text.
- Chose bounding over collapsing the construct into a single combined class: bounding is linear on the whitespace attack vector (collapse is quadratic) and preserves capture-group numbering used by the replacement backreferences and the existing match semantics.
- Added `tests/test_redos.py`: regression test asserting `fang()` returns promptly on adversarial whitespace runs across each vulnerable pattern family.